### PR TITLE
path constraint check

### DIFF
--- a/packages/pytea/src/service/pyteaUtils.ts
+++ b/packages/pytea/src/service/pyteaUtils.ts
@@ -286,6 +286,9 @@ export function runZ3Py<T>(result: ContextSet<T>): void {
     result.getList().forEach((ctx) => {
         jsonList.push(ctx.ctrSet.getConstraintJSON());
     });
+    result.getStopped().forEach((ctx) => {
+        jsonList.push(ctx.ctrSet.getConstraintJSON());
+    });
 
     if (jsonList.length === 0) {
         return;
@@ -305,6 +308,9 @@ export function runZ3Py<T>(result: ContextSet<T>): void {
 export function exportConstraintSet<T>(result: ContextSet<T>, path: string): void {
     const jsonList: string[] = [];
     result.getList().forEach((ctx) => {
+        jsonList.push(ctx.ctrSet.getConstraintJSON());
+    });
+    result.getStopped().forEach((ctx) => {
         jsonList.push(ctx.ctrSet.getConstraintJSON());
     });
 


### PR DESCRIPTION
분석중 한 패스에서 (텐서 모양 오류 등의) 에러를 만나면 해당 패스는 <failed> 처리됨.
문제는 분기 조건문에 의해 실제로는 진행되지 않는 패스여도 <failed>로 처리가 되는 것.

따라서 분석중 에러를 만났을 때 그 패스가 path constraint를 갖고 있으면 <stopped>로 처리하여 z3단에 넘기게 수정하였음.

TODO: z3단에 넘기기 전에 path constraint를 계산하여 Valid면 <failed>, Unsat이면 <success>로 처리하기(else <stopped>)