### PR TITLE
_assignTuple fix

### DIFF
--- a/packages/pytea/src/frontend/torchFrontend.ts
+++ b/packages/pytea/src/frontend/torchFrontend.ts
@@ -823,8 +823,15 @@ export class TorchIRFrontend {
 
         left.expressions.forEach((e, i) => {
             let next: ThStmt | undefined;
-            if (e.nodeType === ParseNodeType.Name) {
-                next = TSAssign.create(TEName.create(e.value, e), TESubscr.create(tempVar, TEConst.genInt(i), e));
+            if (
+                e.nodeType === ParseNodeType.Name ||
+                e.nodeType === ParseNodeType.MemberAccess ||
+                e.nodeType === ParseNodeType.Index
+            ) {
+                next = TSAssign.create(
+                    this.visitExprNode(e) as ThLeftExpr,
+                    TESubscr.create(tempVar, TEConst.genInt(i), e)
+                );
             } else if (e.nodeType === ParseNodeType.List) {
                 next = this._assignList(e, TESubscr.create(tempVar, TEConst.genInt(i), e));
             } else if (e.nodeType === ParseNodeType.Tuple) {


### PR DESCRIPTION
expr1, expr2 = expr3, expr4 형식의 Tuple assign 에서,
왼쪽 표현식(expr1, expr2 )이 attribute인 경우도 가능하도록 확장